### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import { AppDataSource } from "./data-source";
 import userRoutes from "./routes/userRoutes";
 import fileRoutes from "./routes/fileRoutes";
 import * as path from "path";
+import rateLimit from "express-rate-limit";
 
 // Load environment variables
 dotenv.config();
@@ -13,9 +14,16 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Rate limiter middleware
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 // Middleware
 app.use(cors());
 app.use(express.json());
+app.use(limiter);
 
 // Health check endpoint
 app.get('/health', (req: Request, res: Response) => {


### PR DESCRIPTION
Potential fix for [https://github.com/stephondoestech/StratoSafe/security/code-scanning/10](https://github.com/stephondoestech/StratoSafe/security/code-scanning/10)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes, including the one serving static files.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the package in the `backend/src/server.ts` file.
3. Configure the rate limiter middleware.
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
